### PR TITLE
fixed the program optional parameters to be boolean

### DIFF
--- a/waveFunctionCollapse.py
+++ b/waveFunctionCollapse.py
@@ -669,10 +669,10 @@ if __name__ == "__main__":
             raise IndexError
         input_path, pattern_size, out_height, out_width = sys.argv[1:5]
         pattern_size, out_height, out_width = int(pattern_size), int(out_height), int(out_width)
-        flip = sys.argv[5] if len(sys.argv) >= 6 else False
-        rotate = sys.argv[6] if len(sys.argv) >= 7 else False
-        render_iterations = sys.argv[7] if len(sys.argv) >= 8 else True
-        render_video = sys.argv[8] if len(sys.argv) == 9 else True
+        flip = sys.argv[5] == 'True' if len(sys.argv) >= 6 else False
+        rotate = sys.argv[6] == 'True' if len(sys.argv) >= 7 else False
+        render_iterations = sys.argv[7] == 'True' if len(sys.argv) >= 8 else True
+        render_video = sys.argv[8] == 'True' if len(sys.argv) == 9 else True
     except (TypeError, ValueError, IndexError):
         print(USAGE_MSG)
     else:


### PR DESCRIPTION
Hey, 

Following issue #4 where @delhoume mentioned he cannot get the <render_iterations> to not pop up the window it actually doesn't have anything to do with Mac OS. 

The program arguments were left as strings and therefore always have been `True`, even if you specify it as `'False'`. 

A small fix, but it should work now.